### PR TITLE
Change order to make it possible to override existing parser

### DIFF
--- a/lib/util/http.js
+++ b/lib/util/http.js
@@ -57,10 +57,10 @@ exports.setup = function(options, req, res, next) {
         var mime = req.headers['content-type'] || 'application/json';
         mime = mime.split(';')[0]; //Just in case there's multiple mime types, pick the first
 
-        if(autoParse[mime]) {
-          autoParse[mime](req, res, mime, next);
-        } else if(typeof options.mimeParser === 'function') {
+        if (typeof options.mimeParser === 'function') {
           options.mimeParser(req, res, mime, next);
+        } else if(autoParse[mime]) {
+          autoParse[mime](req, res, mime, next);
         } else {
           if(req.headers['content-length']) req.pause();
           next();


### PR DESCRIPTION
The default parser handles "multipart/x-www-form-urlencoded" pretty
bad. This change enables the possibility of using a custom parser for
this mime type which is normally "auto parsed".
